### PR TITLE
*: match keywords in lexer & add a `Datum` struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ lalrpop = {version="0.19.0", features = ["lexer"]}
 
 [workspace]
 members = [
+    ".",
     "./src/ast",
     "./src/datum",
     "./src/error",
@@ -16,6 +17,7 @@ members = [
 ]
 
 default-members = [
+    ".",
     "./src/ast",
     "./src/datum",
     "./src/error",

--- a/src/ast/Cargo.toml
+++ b/src/ast/Cargo.toml
@@ -7,3 +7,6 @@ authors = ["you06 <you1474600@gmail.com>"]
 
 [lib]
 path = "ast.rs"
+
+[dependencies]
+yasp_datum = { path = "../datum" }

--- a/src/ast/dml.rs
+++ b/src/ast/dml.rs
@@ -89,7 +89,7 @@ pub struct UpdateStmt<T: DatumTrait> {
 
 impl<T: DatumTrait> fmt::Display for UpdateStmt<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "update {} set", self.table)?;
+        write!(f, "update {} set ", self.table)?;
         let l = self.list.len();
         for i in 0..l {
             if i != 0 {

--- a/src/ast/dml.rs
+++ b/src/ast/dml.rs
@@ -1,32 +1,7 @@
+use super::expr::Expr;
 use super::model::*;
 use std::fmt;
-
-#[allow(dead_code)]
-pub enum DMLNode {
-    Select(SelectNode),
-}
-
-#[derive(Debug, Eq, PartialEq, Clone)]
-pub struct SelectNode {
-    pub fields: Vec<Field>,
-    pub result_table: CIStr,
-}
-
-impl fmt::Display for SelectNode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "select ")?;
-        let l = self.fields.len();
-        for index in 0..l {
-            write!(f, "{}", self.fields[index])?;
-            if index == l - 1 {
-                break;
-            }
-            write!(f, ",")?;
-        }
-        write!(f, " from {}", self.result_table)?;
-        Ok(())
-    }
-}
+use yasp_datum::DatumTrait;
 
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct Field {
@@ -67,6 +42,60 @@ impl fmt::Display for Field {
         }
         if let Some(column) = &self.column {
             write!(f, "{}", column)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub struct Assignment<T: DatumTrait> {
+    pub field: Field,
+    pub expr: Expr<T>,
+}
+
+impl<T: DatumTrait> fmt::Display for Assignment<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}={}", self.field, self.expr)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub struct SelectStmt {
+    pub fields: Vec<Field>,
+    pub result_table: CIStr,
+}
+
+impl fmt::Display for SelectStmt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "select ")?;
+        let l = self.fields.len();
+        for i in 0..l {
+            if i != 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "{}", self.fields[i])?;
+        }
+        write!(f, " from {}", self.result_table)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub struct UpdateStmt<T: DatumTrait> {
+    pub list: Vec<Assignment<T>>,
+    pub table: CIStr,
+}
+
+impl<T: DatumTrait> fmt::Display for UpdateStmt<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "update {} set", self.table)?;
+        let l = self.list.len();
+        for i in 0..l {
+            if i != 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "{}", self.list[i])?;
         }
         Ok(())
     }

--- a/src/ast/dml.rs
+++ b/src/ast/dml.rs
@@ -6,7 +6,7 @@ pub enum DMLNode {
     Select(SelectNode),
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct SelectNode {
     pub fields: Vec<Field>,
     pub result_table: CIStr,
@@ -28,7 +28,7 @@ impl fmt::Display for SelectNode {
     }
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct Field {
     pub all: bool,
     pub table: Option<CIStr>,

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -1,16 +1,21 @@
-use super::dml::SelectNode;
+use super::dml::{SelectStmt, UpdateStmt};
 use std::fmt;
+use yasp_datum::DatumTrait;
 
 #[derive(Debug, Eq, PartialEq, Clone)]
-pub enum Expr {
-    Select(SelectNode),
+pub enum Expr<T: DatumTrait> {
+    Datum(T),
+    Select(SelectStmt),
+    Update(UpdateStmt<T>),
     UnKnown,
 }
 
-impl fmt::Display for Expr {
+impl<T: DatumTrait> fmt::Display for Expr<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Expr::Select(select_node) => write!(f, "{}", select_node),
+            Expr::Datum(datum) => write!(f, "{}", datum),
+            Expr::Select(node) => write!(f, "{}", node),
+            Expr::Update(node) => write!(f, "{}", node),
             Expr::UnKnown => write!(f, "unknown expression"),
         }
     }

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -1,7 +1,7 @@
 use super::dml::SelectNode;
 use std::fmt;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub enum Expr {
     Select(SelectNode),
     UnKnown,

--- a/src/datum/datum.rs
+++ b/src/datum/datum.rs
@@ -10,7 +10,7 @@ pub trait DatumTrait: Display + Debug + Clone {
     fn from_duration(raw: &str) -> Self;
     fn from_time(raw: &str) -> Self;
     fn from_bytes(raw: &str) -> Self;
-    /// from_raw will parse raw string into specific type
+    /// `from_raw` will parse raw string into specific type
     /// overwrite it at your own risk
     fn from_raw(raw: &str) -> Self {
         if let Ok(num) = raw.parse::<i64>() {

--- a/src/datum/datum.rs
+++ b/src/datum/datum.rs
@@ -1,5 +1,5 @@
-use std::fmt::{Formatter, Display, Debug, Result as FmtResult};
-use chrono::{Utc, DateTime, Duration};
+use chrono::{DateTime, Duration, Utc};
+use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 
 pub trait DatumTrait: Display + Debug {
     fn null() -> Self;
@@ -11,7 +11,7 @@ pub trait DatumTrait: Display + Debug {
     fn from_duration(raw: &str) -> Self;
     fn from_time(raw: &str) -> Self;
     fn from_bytes(raw: &str) -> Self;
-    fn restore(&self) -> &str; 
+    fn restore(&self) -> &str;
 }
 
 #[derive(Debug, PartialEq)]
@@ -44,89 +44,110 @@ pub struct Datum {
 
 impl DatumTrait for Datum {
     fn null() -> Self {
-		Self{kind: Kind::Null}
-	}
+        Self { kind: Kind::Null }
+    }
 
-	fn from_i64(raw: &str) -> Self {
-		let raw = raw.to_string();
-		let num = raw.parse::<i64>().unwrap();
-		Self{kind: Kind::Int64(num)}
-	}
+    fn from_i64(raw: &str) -> Self {
+        let raw = raw.to_string();
+        let num = raw.parse::<i64>().unwrap();
+        Self {
+            kind: Kind::Int64(num),
+        }
+    }
 
     fn from_u64(raw: &str) -> Self {
-		let raw = raw.to_string();
-		let num = raw.parse::<u64>().unwrap();
-		Self{kind: Kind::Uint64(num)}
-	}
+        let raw = raw.to_string();
+        let num = raw.parse::<u64>().unwrap();
+        Self {
+            kind: Kind::Uint64(num),
+        }
+    }
 
     fn from_f32(raw: &str) -> Self {
-		let raw = raw.to_string();
-		let num = raw.parse::<f32>().unwrap();
-		Self{kind: Kind::Float32(num)}
-	}
+        let raw = raw.to_string();
+        let num = raw.parse::<f32>().unwrap();
+        Self {
+            kind: Kind::Float32(num),
+        }
+    }
 
     fn from_f64(raw: &str) -> Self {
-		let raw = raw.to_string();
-		let num = raw.parse::<f64>().unwrap();
-		Self{kind: Kind::Float64(num)}
-	}
+        let raw = raw.to_string();
+        let num = raw.parse::<f64>().unwrap();
+        Self {
+            kind: Kind::Float64(num),
+        }
+    }
 
     fn from_string(raw: &str) -> Self {
-		let raw = raw.to_string();
-		Self{kind: Kind::String(raw)}
-	}
+        let raw = raw.to_string();
+        Self {
+            kind: Kind::String(raw),
+        }
+    }
 
     fn from_duration(raw: &str) -> Self {
-		let raw = raw.to_string();
-		let duration: std::time::Duration = raw.parse::<humantime::Duration>().unwrap().into();
-		let duration = Duration::from_std(duration).unwrap();
-		Self{kind: Kind::MysqlDuration(duration)}
-	}
+        let raw = raw.to_string();
+        let duration: std::time::Duration = raw.parse::<humantime::Duration>().unwrap().into();
+        let duration = Duration::from_std(duration).unwrap();
+        Self {
+            kind: Kind::MysqlDuration(duration),
+        }
+    }
 
-	fn from_time(raw: &str) -> Self {
-		let raw = raw.to_string();
-		let time = raw.parse::<DateTime<Utc>>().unwrap();
-		Self{kind: Kind::MysqlTime(time)}
-	}
+    fn from_time(raw: &str) -> Self {
+        let raw = raw.to_string();
+        let time = raw.parse::<DateTime<Utc>>().unwrap();
+        Self {
+            kind: Kind::MysqlTime(time),
+        }
+    }
 
-	fn from_bytes(raw: &str) -> Self {
-		let bytes = raw.as_bytes().to_vec();
-		Self{kind: Kind::Bytes(bytes)}
-	}
+    fn from_bytes(raw: &str) -> Self {
+        let bytes = raw.as_bytes().to_vec();
+        Self {
+            kind: Kind::Bytes(bytes),
+        }
+    }
 
     fn restore(&self) -> &str {
-		""
-	}
+        ""
+    }
 }
 
 impl Display for Datum {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match &self.kind {
-			Kind::Null => write!(f, "NULL"),
-			Kind::Int64(i) => write!(f, "{}", *i),
-			Kind::Uint64(i) => write!(f, "{}", *i),
-			Kind::Float32(i) => write!(f, "{}", *i),
-			Kind::Float64(i) => write!(f, "{}", *i),
-			Kind::String(i) => write!(f, "{}", *i),
-			Kind::Bytes(bytes) => {
-				let byte_str = String::from_utf8(bytes.clone()).expect("convert to string error");
-				write!(f, "{}", byte_str)
-			},
-			Kind::MysqlDuration(d) => write!(f, "{}", *d),
-			Kind::MysqlTime(d) => write!(f, "{}", *d),
-		}?;
-		Ok(())
+            Kind::Null => write!(f, "NULL"),
+            Kind::Int64(i) => write!(f, "{}", *i),
+            Kind::Uint64(i) => write!(f, "{}", *i),
+            Kind::Float32(i) => write!(f, "{}", *i),
+            Kind::Float64(i) => write!(f, "{}", *i),
+            Kind::String(i) => write!(f, "{}", *i),
+            Kind::Bytes(bytes) => {
+                let byte_str = String::from_utf8(bytes.clone()).expect("convert to string error");
+                write!(f, "{}", byte_str)
+            }
+            Kind::MysqlDuration(d) => write!(f, "{}", *d),
+            Kind::MysqlTime(d) => write!(f, "{}", *d),
+        }?;
+        Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
-	
+    use super::*;
+
     #[test]
     fn test_format() {
-		let datum = Datum::from_i64("123");
-		assert_eq!(datum, Datum{kind: Kind::Int64(123)});
-		assert_eq!(format!("{}", datum), "123");
-	}
+        let datum = Datum::from_i64("123");
+        assert_eq!(
+            datum,
+            Datum {
+                kind: Kind::Int64(123)
+            }
+        );
+        assert_eq!(format!("{}", datum), "123");
+    }
 }

--- a/src/datum/datum.rs
+++ b/src/datum/datum.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Duration, Utc};
 use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 
-pub trait DatumTrait: Display + Debug {
+pub trait DatumTrait: Display + Debug + Clone {
     fn null() -> Self;
     fn from_i64(raw: &str) -> Self;
     fn from_u64(raw: &str) -> Self;
@@ -14,7 +14,7 @@ pub trait DatumTrait: Display + Debug {
     fn restore(&self) -> &str;
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 enum Kind {
     Null,
     Int64(i64),
@@ -37,7 +37,7 @@ enum Kind {
     // MysqlJSON,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Datum {
     kind: Kind,
 }

--- a/src/datum/datum.rs
+++ b/src/datum/datum.rs
@@ -140,7 +140,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_format() {
+    fn test_format_i64() {
         let datum = Datum::from_i64("123");
         assert_eq!(
             datum,
@@ -149,5 +149,16 @@ mod tests {
             }
         );
         assert_eq!(format!("{}", datum), "123");
+    }
+    #[test]
+    fn test_format_u64() {
+        let datum = Datum::from_u64("1926");
+        assert_eq!(
+            datum,
+            Datum {
+                kind: Kind::Uint64(1926)
+            }
+        );
+        assert_eq!(format!("{}", datum), "1926");
     }
 }

--- a/src/error/lib.rs
+++ b/src/error/lib.rs
@@ -1,6 +1,6 @@
 use std::error::Error as StdError;
+use std::fmt::{self, Debug, Display, Formatter};
 use std::result::Result as StdResult;
-use std::fmt::{self, Display, Debug, Formatter};
 
 pub struct Error(Box<ErrorInner>);
 
@@ -11,7 +11,8 @@ struct ErrorInner {
 
 impl Error {
     pub fn new<K>(kind: K) -> Error
-    where K: Display + Send + Sync + 'static
+    where
+        K: Display + Send + Sync + 'static,
     {
         Error(Box::new(ErrorInner {
             kind: Box::new(kind),
@@ -20,8 +21,9 @@ impl Error {
     }
 
     pub fn from_source<E, K>(source: E, kind: K) -> Error
-    where E: StdError + Send + Sync + 'static,
-            K: Display + Send + Sync + 'static
+    where
+        E: StdError + Send + Sync + 'static,
+        K: Display + Send + Sync + 'static,
     {
         Error(Box::new(ErrorInner {
             kind: Box::new(kind),

--- a/src/parser_lalrpop/Cargo.toml
+++ b/src/parser_lalrpop/Cargo.toml
@@ -12,6 +12,7 @@ path = "parser_lalrpop.rs"
 
 [dependencies]
 yasp_ast = { path = "../ast" }
+yasp_datum = { path = "../datum" }
 yasp_error = { path = "../error" }
 
 regex = "1"

--- a/src/parser_lalrpop/parser_lalrpop.rs
+++ b/src/parser_lalrpop/parser_lalrpop.rs
@@ -1,8 +1,8 @@
-use yasp_error::{Result, Error};
-use yasp_ast::expr::{Expr};
-use crate::parsers::grammar::{ExprParser,ExprsParser, Token};
+use crate::parsers::grammar::{ExprParser, ExprsParser, Token};
+use yasp_ast::expr::Expr;
+use yasp_error::{Error, Result};
 
-use lalrpop_util::{ParseError};
+use lalrpop_util::ParseError;
 
 mod parsers {
     #[allow(clippy::all)]
@@ -20,7 +20,7 @@ pub struct Parser;
 
 impl Parser {
     pub fn new() -> Self {
-        Parser{}
+        Parser {}
     }
 
     pub fn parse_expr<T: ToString>(&self, sql: T) -> Result<Expr> {

--- a/src/parser_lalrpop/parser_lalrpop.rs
+++ b/src/parser_lalrpop/parser_lalrpop.rs
@@ -1,5 +1,7 @@
 use crate::parsers::grammar::{ExprParser, ExprsParser, Token};
+use std::marker::PhantomData;
 use yasp_ast::expr::Expr;
+use yasp_datum::DatumTrait;
 use yasp_error::{Error, Result};
 
 use lalrpop_util::ParseError;
@@ -9,38 +11,36 @@ mod parsers {
     pub mod grammar;
 }
 
-type Exprs = Vec<Expr>;
+type Exprs<T> = Vec<Expr<T>>;
 
 fn lalrpop_err(e: ParseError<usize, Token, &str>) -> Error {
     // FIXME: encapsulate error better
     Error::new(format!("parse error: {:?}", e))
 }
 
-pub struct Parser;
+pub struct Parser<T: DatumTrait>(PhantomData<T>);
 
-impl Parser {
-    pub fn new() -> Self {
-        Parser {}
+impl<T: DatumTrait> Parser<T> {
+    pub fn new() -> Parser<T> {
+        Parser(PhantomData)
     }
 
-    pub fn parse_expr<T: ToString>(&self, sql: T) -> Result<Expr> {
-        let sql = sql.to_string();
+    pub fn parse_expr(&self, sql: &str) -> Result<Expr<T>> {
         let parser = ExprParser::new();
-        let ast = parser.parse(&sql);
+        let ast = parser.parse(sql);
         let ast = ast.map_err(lalrpop_err)?;
         Ok(ast)
     }
 
-    pub fn parse<T: ToString>(&self, sql: T) -> Result<Exprs> {
-        let sql = sql.to_string();
+    pub fn parse(&self, sql: &str) -> Result<Exprs<T>> {
         let parser = ExprsParser::new();
-        let ast = parser.parse(&sql);
+        let ast = parser.parse(sql);
         let ast = ast.map_err(lalrpop_err)?;
         Ok(ast)
     }
 }
 
-impl Default for Parser {
+impl<T: DatumTrait> Default for Parser<T> {
     fn default() -> Self {
         Self::new()
     }

--- a/src/parser_lalrpop/parsers/grammar.lalrpop
+++ b/src/parser_lalrpop/parsers/grammar.lalrpop
@@ -6,6 +6,13 @@ use yasp_ast::{
 
 grammar;
 
+match {
+    r"(?i)select" => "SELECT",
+    r"(?i)from" => "FROM",
+} else {
+    _
+}
+
 Comma<T>: Vec<T> = {
     <mut v:(<T> ",")*> <e:T?> => match e {
         None=> v,
@@ -26,10 +33,13 @@ Semicolon<T>: Vec<T> = {
     }
 };
 
+SELECT: &'input str = "SELECT" => <>;
+FROM: &'input str = "FROM" => <>;
+
 pub Exprs = Semicolon<Expr>;
 
 pub Expr: Expr = {
-    "select" <fields: Fields> "from" <result_table: ResultTable> => Expr::Select(SelectNode{
+    SELECT <fields: Fields> FROM <result_table: ResultTable> => Expr::Select(SelectNode{
         fields,
         result_table,
     })
@@ -43,7 +53,7 @@ pub Expr: Expr = {
     // r"(?i)select" => { "select" },
     // r"[0-9a-zA-Z.]+" => <>.into()
 
-Name: CIStr = r"[0-9a-zA-Z_]+" => <>.into();
+Name: CIStr = r"\w+" => <>.into();
 
 Fields = Comma<Field>;
 

--- a/src/parser_lalrpop/parsers/grammar.lalrpop
+++ b/src/parser_lalrpop/parsers/grammar.lalrpop
@@ -1,19 +1,30 @@
 use yasp_ast::{
-    dml::*,
-    expr::*,
-    model::*
+    dml,
+    expr,
+    model
 };
 use yasp_datum::DatumTrait;
 
-grammar<F> where F: DatumTrait;
+grammar<T> where T: DatumTrait;
 
 match {
     r"(?i)select" => "SELECT",
     r"(?i)from" => "FROM",
+    r"(?i)update" => "UPDATE",
+    r"(?i)set" => "SET",
 } else {
     _
 }
 
+/// operators
+EQ: &'input str = "=" => <>;
+/// keywords
+SELECT: &'input str = "SELECT" => <>;
+FROM: &'input str = "FROM" => <>;
+UPDATE: &'input str = "UPDATE" => <>;
+SET: &'input str = "SET" => <>;
+
+/// seperators
 Comma<T>: Vec<T> = {
     <mut v:(<T> ",")*> <e:T?> => match e {
         None=> v,
@@ -34,26 +45,51 @@ Semicolon<T>: Vec<T> = {
     }
 };
 
-SELECT: &'input str = "SELECT" => <>;
-FROM: &'input str = "FROM" => <>;
+/// basic identities
+Name: &'input str = r"\w+" => <>;
 
-pub Exprs = Semicolon<Expr>;
+CIStr: model::CIStr = Name => <>.into();
+Table = CIStr;
+Column = CIStr;
 
-pub Expr: Expr<F> = {
-    SELECT <fields: Fields> FROM <result_table: ResultTable> => Expr::<F>::Select(SelectStmt{
-        fields,
-        result_table,
-    })
+Field: dml::Field = {
+    "*" => dml::Field::new_all(),
+    Column => dml::Field::new_column(<>),
+    <table: Table>"."<column: Column> => dml::Field::new_column(column).with_table(table),
 };
-
-Name: CIStr = r"\w+" => <>.into();
 
 Fields = Comma<Field>;
 
-Field: Field = {
-    "*" => Field::new_all(),
-    Name => Field::new_column(<>),
-    <table: Name>"."<column: Name> => Field::new_column(column).with_table(table),
+Assignment: dml::Assignment<T> = <field: Field> EQ <expr: AssignExpr> => dml::Assignment{
+    field,
+    expr,
 };
 
-ResultTable = Name;
+Assignments = Comma<Assignment>;
+
+AssignExpr: expr::Expr<T> = {
+    Datum,
+    SelectStmt
+};
+
+/// expressions
+pub Exprs = Semicolon<Expr>;
+
+pub Expr: expr::Expr<T> = {
+    Datum,
+    SelectStmt,
+    UpdateStmt
+};
+
+Datum: expr::Expr<T> = Name => expr::Expr::<T>::Datum(T::from_raw(<>));
+
+SelectStmt: expr::Expr<T> = SELECT <fields: Fields> FROM <result_table: Table> => expr::Expr::<T>::Select(dml::SelectStmt{
+    fields,
+    result_table,
+});
+
+UpdateStmt: expr::Expr<T> = UPDATE <table: Table> SET <list: Assignments> => expr::Expr::<T>::Update(dml::UpdateStmt{
+    list,
+    table,
+});
+

--- a/src/parser_lalrpop/parsers/grammar.lalrpop
+++ b/src/parser_lalrpop/parsers/grammar.lalrpop
@@ -3,8 +3,9 @@ use yasp_ast::{
     expr::*,
     model::*
 };
+use yasp_datum::DatumTrait;
 
-grammar;
+grammar<F> where F: DatumTrait;
 
 match {
     r"(?i)select" => "SELECT",
@@ -38,20 +39,12 @@ FROM: &'input str = "FROM" => <>;
 
 pub Exprs = Semicolon<Expr>;
 
-pub Expr: Expr = {
-    SELECT <fields: Fields> FROM <result_table: ResultTable> => Expr::Select(SelectNode{
+pub Expr: Expr<F> = {
+    SELECT <fields: Fields> FROM <result_table: ResultTable> => Expr::<F>::Select(SelectStmt{
         fields,
         result_table,
     })
 };
-
-// Name: CIStr = {
-//     r"(?i)select" => { "select"; },
-//     <value:"identifier"> => { value.into() },
-//     // <r"[0-9a-zA-Z.]+"> => <>.into()
-// };
-    // r"(?i)select" => { "select" },
-    // r"[0-9a-zA-Z.]+" => <>.into()
 
 Name: CIStr = r"\w+" => <>.into();
 

--- a/src/parser_lalrpop/parsers/grammar.lalrpop
+++ b/src/parser_lalrpop/parsers/grammar.lalrpop
@@ -12,6 +12,7 @@ match {
     r"(?i)from" => "FROM",
     r"(?i)update" => "UPDATE",
     r"(?i)set" => "SET",
+    r"(?i)null" => "NULL",
 } else {
     _
 }
@@ -23,6 +24,7 @@ SELECT: &'input str = "SELECT" => <>;
 FROM: &'input str = "FROM" => <>;
 UPDATE: &'input str = "UPDATE" => <>;
 SET: &'input str = "SET" => <>;
+NULL: &'input str = "NULL" => <>;
 
 /// seperators
 Comma<T>: Vec<T> = {
@@ -46,7 +48,10 @@ Semicolon<T>: Vec<T> = {
 };
 
 /// basic identities
-Name: &'input str = r"\w+" => <>;
+Name: &'input str = {
+    r"\w+" => <>,
+    r#""\w+""# => <>,
+}
 
 CIStr: model::CIStr = Name => <>.into();
 Table = CIStr;
@@ -78,10 +83,13 @@ pub Exprs = Semicolon<Expr>;
 pub Expr: expr::Expr<T> = {
     Datum,
     SelectStmt,
-    UpdateStmt
+    UpdateStmt,
 };
 
-Datum: expr::Expr<T> = Name => expr::Expr::<T>::Datum(T::from_raw(<>));
+Datum: expr::Expr<T> = {
+    NULL => expr::Expr::<T>::Datum(T::from_null()),
+    Name => expr::Expr::<T>::Datum(T::from_raw(<>)),
+};
 
 SelectStmt: expr::Expr<T> = SELECT <fields: Fields> FROM <result_table: Table> => expr::Expr::<T>::Select(dml::SelectStmt{
     fields,

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,1 +1,2 @@
 mod select;
+mod update;

--- a/src/tests/select.rs
+++ b/src/tests/select.rs
@@ -64,9 +64,12 @@ mod tests {
             "select Sakura.ShiZuKu,rin,* from Sakura"
         );
 
-        let exprs = parser
-            .parse("select * from sakura;    select Sakura.ShiZuKu, rin, * from Sakura")
-            .unwrap();
+        let exprs =
+            parser.parse("select * from sakura;    select Sakura.ShiZuKu, rin, * from Sakura").unwrap();
+        assert_eq!(exprs, vec![expr1.clone(), expr2.clone()]);
+
+        let exprs =
+            parser.parse("SeLecT * fRom sakura;    sElect Sakura.ShiZuKu, rin, * FroM Sakura").unwrap();
         assert_eq!(exprs, vec![expr1, expr2]);
     }
 }

--- a/src/tests/select.rs
+++ b/src/tests/select.rs
@@ -64,12 +64,14 @@ mod tests {
             "select Sakura.ShiZuKu,rin,* from Sakura"
         );
 
-        let exprs =
-            parser.parse("select * from sakura;    select Sakura.ShiZuKu, rin, * from Sakura").unwrap();
+        let exprs = parser
+            .parse("select * from sakura;    select Sakura.ShiZuKu, rin, * from Sakura")
+            .unwrap();
         assert_eq!(exprs, vec![expr1.clone(), expr2.clone()]);
 
-        let exprs =
-            parser.parse("SeLecT * fRom sakura;    sElect Sakura.ShiZuKu, rin, * FroM Sakura").unwrap();
+        let exprs = parser
+            .parse("SeLecT * fRom sakura;    sElect Sakura.ShiZuKu, rin, * FroM Sakura")
+            .unwrap();
         assert_eq!(exprs, vec![expr1, expr2]);
     }
 }

--- a/src/tests/select.rs
+++ b/src/tests/select.rs
@@ -1,16 +1,17 @@
 #[cfg(test)]
 mod tests {
     use yasp_ast::{dml::*, expr::*, model::*};
+    use yasp_datum::Datum;
     use yasp_parser_lalrpop::Parser;
 
     #[test]
     fn test_select() {
-        let parser = Parser::new();
+        let parser = Parser::<Datum>::new();
 
         let expr1 = parser.parse_expr("select * from sakura").unwrap();
         assert_eq!(
             expr1,
-            Expr::Select(SelectNode {
+            Expr::Select(SelectStmt {
                 fields: vec![Field {
                     all: true,
                     table: None,
@@ -26,7 +27,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             expr2,
-            Expr::Select(SelectNode {
+            Expr::Select(SelectStmt {
                 fields: vec![
                     Field {
                         all: false,
@@ -61,7 +62,7 @@ mod tests {
         );
         assert_eq!(
             &format!("{}", expr2),
-            "select Sakura.ShiZuKu,rin,* from Sakura"
+            "select Sakura.ShiZuKu, rin, * from Sakura"
         );
 
         let exprs = parser

--- a/src/tests/update.rs
+++ b/src/tests/update.rs
@@ -1,0 +1,36 @@
+#[cfg(test)]
+mod tests {
+    use yasp_ast::{dml::*, expr::*};
+    use yasp_datum::{Datum, Kind};
+    use yasp_parser_lalrpop::Parser;
+
+    #[test]
+    fn test_update() {
+        let parser = Parser::<Datum>::new();
+
+        let expr1 = parser
+            .parse_expr("update sakura set rin=7, shizuku = 13")
+            .unwrap();
+        assert_eq!(
+            expr1,
+            Expr::Update(UpdateStmt {
+                table: "sakura".into(),
+                list: vec![
+                    Assignment {
+                        field: Field::new_column("rin".into()),
+                        expr: Expr::Datum(Datum {
+                            kind: Kind::Int64(7),
+                        }),
+                    },
+                    Assignment {
+                        field: Field::new_column("shizuku".into()),
+                        expr: Expr::Datum(Datum {
+                            kind: Kind::Int64(13),
+                        }),
+                    }
+                ],
+            })
+        );
+        assert_eq!(&format!("{}", expr1), "update sakura set rin=7, shizuku=13");
+    }
+}

--- a/src/tests/update.rs
+++ b/src/tests/update.rs
@@ -9,7 +9,7 @@ mod tests {
         let parser = Parser::<Datum>::new();
 
         let expr1 = parser
-            .parse_expr("update sakura set rin=7, shizuku = 13")
+            .parse_expr("update sakura set rin=7, shizuku = \"13\"")
             .unwrap();
         assert_eq!(
             expr1,
@@ -25,12 +25,15 @@ mod tests {
                     Assignment {
                         field: Field::new_column("shizuku".into()),
                         expr: Expr::Datum(Datum {
-                            kind: Kind::Int64(13),
+                            kind: Kind::String("13".to_owned()),
                         }),
                     }
                 ],
             })
         );
-        assert_eq!(&format!("{}", expr1), "update sakura set rin=7, shizuku=13");
+        assert_eq!(
+            &format!("{}", expr1),
+            "update sakura set rin=7, shizuku=\"13\""
+        );
     }
 }


### PR DESCRIPTION
Match keywords before parse SQL makes keywords case-insensitive.

The lib itself offers a `Datum` struct. Also users can implement `DatumTrait` and use their own `Datum`.
